### PR TITLE
ci: Enable multi-arch Docker publish (amd64/arm64) for ARM use cases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # 1. Login to GitHub Container Registry
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -54,6 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi! I put together this PR to add ARM64 image publishing in CI, so images work on both ARM Linux and Apple Silicon macOS (it also fits my ARM64 home-router setup).

- Added QEMU + Buildx in GitHub Actions  
- Docker publish now targets: `linux/amd64,linux/arm64`

Thanks for taking a look.