### PR TITLE
Real time Bypass notification

### DIFF
--- a/NeoHub/NeoHub/Api/WebSocket/Models/WebSocketMessage.cs
+++ b/NeoHub/NeoHub/Api/WebSocket/Models/WebSocketMessage.cs
@@ -53,6 +53,7 @@ namespace NeoHub.Api.WebSocket.Models
         public required string SessionId { get; init; }
         public required byte ZoneNumber { get; init; }
         public required bool Open { get; init; }
+        public required bool Bypassed { get; init; }
     }
 
     public record ErrorMessage : WebSocketMessage
@@ -85,6 +86,7 @@ namespace NeoHub.Api.WebSocket.Models
         public required string Name { get; init; }
         public required string DeviceClass { get; init; }
         public required bool Open { get; init; }
+        public required bool Bypassed { get; init; }
         public required List<byte> Partitions { get; init; }
     }
 

--- a/NeoHub/NeoHub/Api/WebSocket/PanelWebSocketHandler.cs
+++ b/NeoHub/NeoHub/Api/WebSocket/PanelWebSocketHandler.cs
@@ -196,6 +196,7 @@ namespace NeoHub.Api.WebSocket
                                 Name = kvp.Value.DisplayName,
                                 DeviceClass = DetermineDeviceClass(kvp.Value),
                                 Open = kvp.Value.IsOpen,
+                                Bypassed = kvp.Value.IsBypassed,
                                 Partitions = kvp.Value.Partitions
                             })
                             .ToList()
@@ -330,14 +331,15 @@ namespace NeoHub.Api.WebSocket
                 return;
             }
 
-            _logger.LogDebug("Broadcasting zone_update: Session={SessionId}, Zone={Zone}, Open={Open}",
-                e.SessionId, e.Zone.ZoneNumber, e.Zone.IsOpen);
+            _logger.LogDebug("Broadcasting zone_update: Session={SessionId}, Zone={Zone}, Open={Open}, Bypassed={Bypassed}",
+                e.SessionId, e.Zone.ZoneNumber, e.Zone.IsOpen, e.Zone.IsBypassed);
 
             var message = new ZoneUpdateMessage
             {
                 SessionId = e.SessionId,
                 ZoneNumber = e.Zone.ZoneNumber,
-                Open = e.Zone.IsOpen
+                Open = e.Zone.IsOpen,
+                Bypassed = e.Zone.IsBypassed
             };
 
             _ = BroadcastMessageAsync(message);

--- a/NeoHub/NeoHub/Components/Pages/Home.razor
+++ b/NeoHub/NeoHub/Components/Pages/Home.razor
@@ -89,7 +89,9 @@
                         <MudCard Elevation="1" Class="mb-3">
                             <MudCardHeader>
                                 <CardHeaderContent>
-                                    <MudText Typo="Typo.h6">@partition.DisplayName</MudText>
+                                    <MudLink Typo="Typo.h6" Href="@($"zones/{sessionId}/{partitionNumber}")" Underline="Underline.Hover" Color="Color.Inherit">
+                                        @partition.DisplayName
+                                    </MudLink>
                                 </CardHeaderContent>
                                 <CardHeaderActions>
                                     <MudChip T="string"

--- a/NeoHub/NeoHub/Services/Handlers/BypassStatusNotificationHandler.cs
+++ b/NeoHub/NeoHub/Services/Handlers/BypassStatusNotificationHandler.cs
@@ -1,0 +1,49 @@
+using DSC.TLink.ITv2.MediatR;
+using DSC.TLink.ITv2.Messages;
+using MediatR;
+using NeoHub.Services.Models;
+
+namespace NeoHub.Services.Handlers
+{
+    /// <summary>
+    /// Handles single zone bypass status notifications (real-time bypass/unbypass events).
+    /// Updates the zone's IsBypassed state so the UI reflects changes made from any source
+    /// (keypad, ITv2, DLS).
+    /// </summary>
+    public class BypassStatusNotificationHandler
+        : INotificationHandler<SessionNotification<SingleZoneBypassStatus>>
+    {
+        private readonly IPanelStateService _service;
+        private readonly ILogger<BypassStatusNotificationHandler> _logger;
+
+        public BypassStatusNotificationHandler(
+            IPanelStateService service,
+            ILogger<BypassStatusNotificationHandler> logger)
+        {
+            _service = service;
+            _logger = logger;
+        }
+
+        public Task Handle(
+            SessionNotification<SingleZoneBypassStatus> notification,
+            CancellationToken cancellationToken)
+        {
+            var msg = notification.MessageData;
+            var sessionId = notification.SessionId;
+
+            var zone = _service.GetZone(sessionId, msg.ZoneNumber)
+                ?? new ZoneState { ZoneNumber = msg.ZoneNumber };
+
+            zone.IsBypassed = msg.BypassState != 0;
+            zone.LastUpdated = notification.ReceivedAt;
+
+            _logger.LogDebug(
+                "Zone {Zone} bypass status: {Status}",
+                msg.ZoneNumber, zone.IsBypassed ? "BYPASSED" : "NOT BYPASSED");
+
+            _service.UpdateZone(sessionId, zone);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/NeoHub/TLink/ITv2/Messages/SingleZoneBypassStatus.cs
+++ b/NeoHub/TLink/ITv2/Messages/SingleZoneBypassStatus.cs
@@ -1,0 +1,43 @@
+// DSC TLink - a communications library for DSC Powerseries NEO alarm panels
+// Copyright (C) 2024 Brian Humlicek
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using DSC.TLink.ITv2.Enumerations;
+using DSC.TLink.Serialization;
+
+namespace DSC.TLink.ITv2.Messages
+{
+	/// <summary>
+	/// Real-time notification from the panel indicating a zone's bypass state has changed.
+	/// Sent after a bypass/unbypass operation (from keypad, ITv2, or DLS).
+	/// 
+	/// Observed wire format (payload after command word):
+	///   [CompactInt: ZoneNumber] [byte: BypassState]
+	///   [01-05-00] = Zone 5 unbypassed
+	///   [01-05-01] = Zone 5 bypassed
+	/// </summary>
+	[ITv2Command(ITv2Command.ModuleStatus_Single_Zone_Bypass_Status)]
+	public record SingleZoneBypassStatus : IMessageData
+	{
+		[CompactInteger]
+		public byte ZoneNumber { get; init; }
+
+		/// <summary>
+		/// 0 = zone is not bypassed (normal monitoring),
+		/// 1 = zone is bypassed (excluded from monitoring).
+		/// </summary>
+		public byte BypassState { get; init; }
+	}
+}


### PR DESCRIPTION
Currently, the Bypass status is only read when connecting to the panel.
This PR adds handling of `SingleZoneBypassStatus` messages from the panel.
Additionally, the partition name is now clickable and redirects to the details view—this view already existed, but there was no way to access it.

I tried setting the bypass remotely from NeoHub as well, but it's not that simple. I'm publishing what works for now that can be merged.

<img width="708" height="260" alt="image" src="https://github.com/user-attachments/assets/f9580070-6dd3-42cc-8202-79d88648263e" />

Partition details page:

<img width="1864" height="601" alt="image" src="https://github.com/user-attachments/assets/1974ee33-5ae9-4301-85e0-e7ad7ea063f0" />

Debug messages:
```
ITv2Session:
RX detail: [SingleZoneBypassStatus]
ZoneNumber = 5
BypassState = 0

ITv2Session
RX detail: [SingleZoneBypassStatus]
ZoneNumber = 5
BypassState = 1
```
